### PR TITLE
Fix database router with Django migrations

### DIFF
--- a/backend/backend/dbrouter.py
+++ b/backend/backend/dbrouter.py
@@ -1,11 +1,16 @@
 # coding: utf-8
 from django.conf import settings
+import django.apps
 
 
 class SimpleRouter(object):
 
     def _is_platal1_model(self, model):
-        return model.__module__.startswith('platal.')
+        # Django migrations use __fake__ objects, unrelated to the real module.
+        # So find the App which holds the module and find out whether the app
+        # lies in the platal namespace.
+        appcfg = django.apps.apps.get_app_config(model._meta.app_label)
+        return appcfg.module.__name__.startswith('platal.')
 
     def db_for_read(self, model, **hints):
         if self._is_platal1_model(model):


### PR DESCRIPTION
Django migrations use **fake** objects which do not have any modules
